### PR TITLE
Update readme to reflect correct parameters for createJsonForm

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Then the JSON should be
          */
         public function actionCreateAction(Request $request, $uuid) {
             $action = new Action();
-            $form = $this->createJsonForm(new ActionType(), $action);
+            $form = $this->createJsonForm(ActionType::class, $action);
             $this->handleJsonForm($form, $request);
 
             $em = $this->getDoctrine()->getManager();


### PR DESCRIPTION
Symfony FormFactory class expects a string for the form type, not an object. Update the example to reflect this.